### PR TITLE
feat(traefik): serve wildcard as default cert to close restart self-s…

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -61,6 +61,21 @@ dnsmasq_lines = [
 
 **Why the `::` line matters (was the cause of a self-signed-cert outage on `fin.`):** FTL only applies the IPv4 `address=` override to A queries — AAAA queries for these names leak upstream and return Cloudflare's real IPv6. The Pi has **no IPv6**, so a dual-stack browser split-brains: it reaches Cloudflare over v6 (valid cert + HSTS pin) but Traefik directly over v4. Any moment Traefik serves its `TRAEFIK DEFAULT CERT` (self-signed fallback for an unmatched SNI, e.g. during a restart before `acme.json` loads) then becomes an **unbypassable** `MOZILLA_PKIX_ERROR_SELF_SIGNED_CERT` block because of the HSTS pin. The `::` sinkhole makes FTL authoritative for AAAA, so browsers fail-fast on v6 and consistently use IPv4 → Traefik → valid cert. Apply changes with `sudo systemctl restart pihole-FTL`.
 
+### Traefik default certificate — closes the restart self-signed window
+
+The `::` sinkhole removes the IPv6 split-brain, but the **self-signed-during-restart** half of that failure remained: measured with a 50 ms probe across a `systemctl --user restart traefik`, there is a sub-second window where `:443` is back up but per-host certs have not yet loaded from `acme.json`, and Traefik serves its self-signed `TRAEFIK DEFAULT CERT`. A browser reconnecting in that window (open Home Assistant / Jellyfin / Vaultwarden tabs retry aggressively) gets the sticky HSTS cert error again on the LAN direct path — i.e. the problem comes back on every restart/reboot until the browser's state is cleared.
+
+Fix — serve a **valid wildcard as the store's default certificate**, delivered by the *file* provider (which loads before the ACME certs), so the self-signed cert is never served:
+
+- `dynamic/tls.yml` → `tls.stores.default.defaultCertificate` points at `certs/default.{crt,key}`.
+- Those PEM files are the `*.youssefalhassan.com` wildcard, mirrored from `acme.json` by `extract-default-cert.py`.
+- The wildcard is issued/auto-renewed by the `tls.domains` block on the `traefik-dashboard` router in `services.yml`. (`defaultCertificate` and `defaultGeneratedCert` are mutually exclusive in Traefik — the warning `cannot be defined at the same time` — so renewal is driven from a router, not from the store.)
+- `traefik-default-cert.timer` (systemd `--user`, daily) re-runs the mirror so a renewed wildcard is copied to PEM; on change it touches `tls.yml` to trigger a hot-reload.
+
+Verified: after the fix, a 50 ms restart probe of `ha`/`jf` shows only valid-cert (`ssl_verify=0`) or brief connection-refused samples — **zero** self-signed samples. Connection-refused during the ~1 s restart is harmless (browser retries against a valid cert); it does not pin HSTS.
+
+Files: `traefik/dynamic/tls.yml`, `traefik/extract-default-cert.py`, `traefik/certs/`, `~/.config/systemd/user/traefik-default-cert.{service,timer}`.
+
 ## Traefik Routes
 
 File: `~/infra/traefik/dynamic/services.yml`  

--- a/docs/services.md
+++ b/docs/services.md
@@ -6,7 +6,7 @@ Last updated: 2026-07-08
 
 | Service | Port (local) | Subdomain | Quadlet | Notes |
 |---------|-------------|-----------|---------|-------|
-| Traefik v3 | 80, 443 (host) | `proxy.youssefalhassan.com` | `traefik.container` | Reverse proxy, host-network, LetsEncrypt via DNS |
+| Traefik v3 | 80, 443 (host) | `proxy.youssefalhassan.com` | `traefik.container` | Reverse proxy, host-network, LetsEncrypt via DNS. Serves a `*.youssefalhassan.com` wildcard as the store **default cert** (`dynamic/tls.yml` → `certs/default.{crt,key}`, mirrored from `acme.json` by `extract-default-cert.py` / `traefik-default-cert.timer`) so no self-signed cert is served during the restart window — see `docs/networking.md`. |
 | Authelia | 127.0.0.1:9100 | `auth.youssefalhassan.com` | `authelia.container` | SSO / forward-auth middleware |
 | VaultWarden | 127.0.0.1:8081 | `vw.youssefalhassan.com` | `vaultwarden.container` | Password manager; data in `infra/vault-warden/data` (note hyphenated dir) |
 | Home Assistant | 127.0.0.1:8123 (host-net) | `ha.youssefalhassan.com` | `home-assistant.container` | Smart home |

--- a/traefik/dynamic/services.yml
+++ b/traefik/dynamic/services.yml
@@ -35,6 +35,13 @@ http:
       middlewares: [authelia]
       tls:
         certResolver: letsencrypt
+        # Issues + auto-renews the zone wildcard in acme.json. It's mirrored to
+        # PEM (extract-default-cert.py) and served as the default cert to close
+        # the restart-window self-signed gap. See dynamic/tls.yml.
+        domains:
+          - main: "youssefalhassan.com"
+            sans:
+              - "*.youssefalhassan.com"
 
     jellyfin:
       rule: "Host(`jf.youssefalhassan.com`)"

--- a/traefik/dynamic/tls.yml
+++ b/traefik/dynamic/tls.yml
@@ -1,0 +1,26 @@
+# Default TLS certificate for the whole zone.
+#
+# Purpose: during a Traefik restart there is a brief window after :443 reopens
+# but before per-host certs load from acme.json. Without a default cert, Traefik
+# serves its built-in self-signed "TRAEFIK DEFAULT CERT" during that window. On
+# the LAN direct-to-Traefik path, a browser holding the zone's HSTS pin then gets
+# a *sticky, unbypassable* cert error for whatever subdomain it hit. See
+# docs/networking.md (the fin. self-signed-cert outage).
+#
+# A valid wildcard as the store default means any SNI — matched, unmatched, or
+# not-yet-loaded — is served a trusted cert instead of the self-signed fallback.
+tls:
+  stores:
+    default:
+      # Served during the restart window: file-provider certs load before ACME
+      # certs come out of acme.json, so this closes the self-signed gap that
+      # otherwise re-poisons HSTS-pinned browsers on the LAN direct path.
+      #
+      # This is the *.youssefalhassan.com wildcard, mirrored from acme.json by
+      # extract-default-cert.py (traefik-default-cert.timer, daily). The wildcard
+      # is issued/renewed by the tls.domains block on the traefik-dashboard
+      # router in services.yml. (defaultCertificate and defaultGeneratedCert are
+      # mutually exclusive in Traefik, so renewal is driven from a router.)
+      defaultCertificate:
+        certFile: /etc/traefik/certs/default.crt
+        keyFile: /etc/traefik/certs/default.key

--- a/traefik/extract-default-cert.py
+++ b/traefik/extract-default-cert.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Extract the *.youssefalhassan.com wildcard from Traefik's acme.json into PEM
+files that the Traefik file provider serves as the store's default certificate.
+
+Why: on a Traefik restart there is a brief window after :443 reopens but before
+certs load from acme.json, during which Traefik serves its built-in self-signed
+"TRAEFIK DEFAULT CERT". On the LAN direct-to-Traefik path a browser holding the
+zone's HSTS pin then gets a sticky, unbypassable cert error. A static
+defaultCertificate is delivered by the file provider (independent of acme.json),
+so it is present during that window and the self-signed cert is never served.
+
+Traefik keeps the wildcard itself issued and renewed (defaultGeneratedCert in
+dynamic/tls.yml); this script just mirrors it to PEM. Run on a daily timer so a
+renewed wildcard is picked up. On change it touches dynamic/tls.yml to trigger a
+hot-reload (no restart, no downtime).
+"""
+import base64
+import json
+import os
+import sys
+
+HOME = os.environ.get("HOME", os.path.expanduser("~"))
+ACME = os.path.join(HOME, "infra/traefik/acme/acme.json")
+OUT = os.path.join(HOME, "infra/traefik/certs")
+RELOAD_TRIGGER = os.path.join(HOME, "infra/traefik/dynamic/tls.yml")
+MAIN = "youssefalhassan.com"  # wildcard cert's domain.main
+
+
+def find_wildcard(acme):
+    for resolver in acme.values():
+        for cert in resolver.get("Certificates") or []:
+            if cert.get("domain", {}).get("main") == MAIN:
+                return cert
+    return None
+
+
+def write_if_changed(path, data, mode):
+    if os.path.exists(path):
+        with open(path, "rb") as f:
+            if f.read() == data:
+                return False
+    tmp = path + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(data)
+    os.chmod(tmp, mode)
+    os.replace(tmp, path)
+    return True
+
+
+def main():
+    with open(ACME) as f:
+        acme = json.load(f)
+    cert = find_wildcard(acme)
+    if not cert:
+        print(f"ERROR: wildcard cert (main={MAIN}) not found in {ACME}", file=sys.stderr)
+        return 1
+    crt = base64.b64decode(cert["certificate"])
+    key = base64.b64decode(cert["key"])
+    os.makedirs(OUT, exist_ok=True)
+    changed = False
+    changed |= write_if_changed(os.path.join(OUT, "default.crt"), crt, 0o644)
+    changed |= write_if_changed(os.path.join(OUT, "default.key"), key, 0o600)
+    if changed:
+        os.utime(RELOAD_TRIGGER, None)  # bump mtime -> Traefik file provider reloads
+        print("default cert updated; triggered Traefik reload")
+    else:
+        print("default cert unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
Serve the `*.youssefalhassan.com` wildcard as Traefik's **store default certificate**, delivered by the file provider, so the built-in self-signed `TRAEFIK DEFAULT CERT` is never served.

## Why
On a Traefik restart there is a sub-second window where `:443` is back up but per-host certs have not yet loaded from `acme.json`. During that window Traefik serves its self-signed fallback. On the LAN direct-to-Traefik path, a browser holding the zone's HSTS pin then gets a **sticky, unbypassable** cert error — recurring on every restart/reboot until browser state is cleared. This is the second half of the `fin.` self-signed outage (the IPv6 split-brain half was already fixed by the Pi-hole `::` sinkhole).

## How
- **`dynamic/tls.yml`** (new): `tls.stores.default.defaultCertificate` → `certs/default.{crt,key}` (file provider loads before ACME certs).
- **`extract-default-cert.py`** (new): mirrors the wildcard out of `acme.json` into PEM; run daily by `traefik-default-cert.timer`, touches `tls.yml` to hot-reload.
- **`dynamic/services.yml`**: `tls.domains` on the dashboard router issues/renews the wildcard (`defaultCertificate`/`defaultGeneratedCert` are mutually exclusive).
- Docs: new "Traefik default certificate" section in `networking.md`; Traefik row in `services.md`.

## Verified
A 50 ms restart probe of `ha`/`jf` shows only valid-cert or brief connection-refused samples — **zero** self-signed samples.

## Notes for reviewers
- PEM secrets (`traefik/certs/default.{crt,key}`) are gitignored — only generator + config committed.
- The systemd `--user` timer/service lives outside the repo (`~/.config/systemd/user/`), like quadlets here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit wildcard certificate coverage for the Traefik dashboard and primary domain.
  * Added a fallback TLS certificate to prevent self-signed certificates from appearing during service restarts or reloads.
  * Certificates are automatically refreshed when the active ACME certificate changes.

* **Documentation**
  * Added troubleshooting guidance and verification steps for DNS/LAN certificate behavior.
  * Expanded service documentation with details about certificate fallback and renewal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->